### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,16 @@
+# Setup
+
+This project comes with Go 1.6 already installed.
+
+# Compile
+
+To run the program, simply run `go run {file}.go`
+
+# Additional Tools
+
+You can also browse Go documentation from your project by running:
+
+`godoc -http=0.0.0.0:6060`
+
+Once this is running, simply go to `Preview > Port 6060` in the IDE menu.
+You will then be able to browse the documentation as you need them.

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,6 @@
+{
+  "template": "golang",
+  "ports": [],
+  "name": "Go Examples",
+  "description": "Go(lang) examples - (explain the basics of golang)"
+}

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,16 @@ sudo apt-get install golang
 or  
 [compile it yourself](https://golang.org/doc/install/source)  
 
+## Nitrous Quickstart
+
+You can quickly create a free development environment for this Go Examples project in the cloud on www.nitrous.io:
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+To run the program, simply run `go run {file}.go` in `~/code/golang-examples`.
+
 ## examples
 
 The examples are divided into three levels of difficulty. [beginner](https://github.com/SimonWaldherr/golang-examples#beginner) contains very easy examples, starting with **Hello World** but also containing a few easy algorithms. [advanced](https://github.com/SimonWaldherr/golang-examples#advanced) uses more complicated features of golang. [expert](https://github.com/SimonWaldherr/golang-examples#expert) contains applications like telnet-clients or http-server (even with SSL).  


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.
