### PR TITLE
Improve bcrypt example

### DIFF
--- a/advanced/bcrypt.go
+++ b/advanced/bcrypt.go
@@ -2,17 +2,14 @@ package main
 
 import (
 	"fmt"
+
 	"golang.org/x/crypto/bcrypt"
 )
-
-// Hashing cost for bcrypt, higher is better but will slow to create and compare hash
-// Minimum cost is 4
-const HashingCost = 8
 
 // Will create hash password
 // It should never panic if plainText is given properly
 func CreateHash(plainText string) (hashText string) {
-	passwordHashInBytes, err := bcrypt.GenerateFromPassword([]byte(plainText), HashingCost)
+	passwordHashInBytes, err := bcrypt.GenerateFromPassword([]byte(plainText), bcrypt.DefaultCost)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR improves the bcrypt example by using the `DefaultCost` constant (which is currently 10 and the recommended value instead of the previously used 8) and by allowing password which are longer than 72 characters.

Bcrypt truncates the plaintext input at 72 characters, so passwords which are longer than that, are not recognized as different inputs. By hashing the input first to a fixed size (and removing possible NULL bytes) an arbitrary long input is possible.