### PR TITLE
Add encryption example with AES-GCM

### DIFF
--- a/advanced/aesgcm.go
+++ b/advanced/aesgcm.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+// AesGcmEncrypt takes an encryption key and a plaintext string and encrypts it with AES256 in GCM mode, which provides authenticated encryption. Returns the ciphertext and the used nonce.
+func AesGcmEncrypt(key []byte, plaintext string) (ciphertext, nonce []byte) {
+	plaintextBytes := []byte(plaintext)
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// Never use more than 2^32 random nonces with a given key because of the risk of a repeat.
+	nonce = make([]byte, 12)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		panic(err.Error())
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	ciphertext = aesgcm.Seal(nil, nonce, plaintextBytes, nil)
+	fmt.Printf("Ciphertext: %x\n", ciphertext)
+	fmt.Printf("Nonce: %x\n", nonce)
+
+	return
+}
+
+// AesGcmDecrypt takes an decryption key, a ciphertext and the corresponding nonce and decrypts it with AES256 in GCM mode. Returns the plaintext string.
+func AesGcmDecrypt(key, ciphertext, nonce []byte) (plaintext string) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	plaintextBytes, err := aesgcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	plaintext = string(plaintextBytes)
+	fmt.Printf("%s\n", plaintext)
+
+	return
+}
+
+func main() {
+	// Generate an encryption key. 16 bytes = AES-128, 32 bytes = AES-256.
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		panic(err.Error())
+	}
+
+	// Specify the plaintext input
+	plaintext := "Lorem Ipsum"
+	ciphertext, nonce := AesGcmEncrypt(key, plaintext)
+
+	// For decryption you need to provide the nonce which was used for the encryption
+	plaintext = AesGcmDecrypt(key, ciphertext, nonce)
+}

--- a/readme.md
+++ b/readme.md
@@ -217,6 +217,12 @@ go run oop.go
 
 ### Advanced
 
+AES-GCM encryption example
+
+```
+go run aesgcm.go
+```
+
 Bcrypt hashing example
 
 Please install package golang.org/x/crypto/bcrypt before run this file by running `go get golang.org/x/crypto/bcrypt`


### PR DESCRIPTION
Adds a simple example how to use encryption with AES in GCM mode, which provides authenticated encryption.