### PR TITLE
Remove instructions to click Code Sponsor link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -458,7 +458,6 @@ you can do so by:
 * [donate via PayPal](https://www.paypal.me/SimonWaldherr "Donate to this project via PayPal.me")
 * buy me a beer at a conference
 * give me a job where i can work on open source projects
-* click on these ads (powered by [codesponsor.io](https://codesponsor.io/))
 
 <a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/bpWGS5JKXiHEB18kfHGr1x3q/SimonWaldherr/golang-examples'>
   <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/bpWGS5JKXiHEB18kfHGr1x3q/SimonWaldherr/golang-examples.svg' />


### PR DESCRIPTION
You cannot instruct visitors to click on the link to support your project. Please make sure this is the case with all repositories being sponsored through Code Sponsor ❤️