### PR TITLE
Remove reference to standalone cobra cli

### DIFF
--- a/non-std-lib/README.md
+++ b/non-std-lib/README.md
@@ -11,12 +11,12 @@ This directory has Golang code examples that contain at least one import that is
 Golang comes with a builtin tool for downloading and installing packages called `get`.
 
 #### Common Usage: `go get [packages]`
-- `go get github.com/spf13/cobra/cobra`
+- `go get github.com/spf13/cobra`
 - `go get golang.org/x/net/html`
 
 `go get`also allows you to pass flags such as `-u` for updating a package that is already installed on your computer.
 
-- `go get -u github.com/spf13/cobra/cobra`
+- `go get -u github.com/spf13/cobra`
 - `go get -u golang.org/x/net/html`
 
 For more information about to use `go get` and the other flags that may be used, see the [Golang Documentation](https://golang.org/cmd/go/#hdr-Download_and_install_packages_and_dependencies).
@@ -33,16 +33,16 @@ The supported version control systems are:
 	Mercurial   .hg
 	Subversion  .svn
 	
-When using `go get` to retrieve a package such as `github.com/spf13/cobra/cobra`, go get will make a http(s) request for that package. 
+When using `go get` to retrieve a package such as `github.com/spf13/cobra`, go get will make a http(s) request for that package. 
 
 Given that different vcs have different implementations, go get must know which vcs it is dealing with before it can successfully download the package.
 
-1. If the path name has vcs extension, such as `github.com/spf13/cobra/cobra.git`, then go get knows to download the package via git.
+1. If the path name has vcs extension, such as `github.com/spf13/cobra.git`, then go get knows to download the package via git.
 
-2. If the path name does not have a vcs extension, such as `github.com/spf13/cobra/cobra`, then the html page must have a meta of the following form that indicates which vcs was used.
+2. If the path name does not have a vcs extension, such as `github.com/spf13/cobra`, then the html page must have a meta of the following form that indicates which vcs was used.
 	
     `<meta name="go-import" content="import-prefix vcs repo-root">`
 
-    The meta tag for `github.com/spf13/cobra/cobra` is `<meta name="go-import" content="github.com/spf13/cobra git https://github.com/spf13/cobra.git">`
+    The meta tag for `github.com/spf13/cobra` is `<meta name="go-import" content="github.com/spf13/cobra git https://github.com/spf13/cobra.git">`
 
 For more information on remote import paths, see the [Golang Documentation](https://golang.org/cmd/go/#hdr-Import_path_syntax)


### PR DESCRIPTION
Switches the go get commands to use the cobra library instead of the cobra/cobra command, since the command is being removed from the github.com/spf13/cobra module (xref https://github.com/spf13/cobra/issues/1597)